### PR TITLE
Allow query-param hashes in chunk names

### DIFF
--- a/source/chunks plugin.js
+++ b/source/chunks plugin.js
@@ -48,7 +48,7 @@ function filename_info(json, assets_base_url)
 
 		return chunk
 			// filter by extension
-			.filter(name => path.extname(name) === `.${extension}`)
+			.filter(name => path.extname(name).split('?')[0] === `.${extension}`)
 			// adjust the real path (can be http, filesystem)
 			.map(name => assets_base_url + name)
 	}


### PR DESCRIPTION
We use query params for cache-busting (eg, `filename: '[name].js?[chunkhash]'`), which trips up the current filter & breaks the webpack build. This change would account for query params.