### PR TITLE
Add missing `cssBundle` to client options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,8 +25,9 @@ export interface UniversalConfiguration {
 }
 
 export interface ClientConfigurationOptions {
-    development?: boolean,
-    useMiniCssExtractPlugin?: boolean
+    development?: boolean;
+    useMiniCssExtractPlugin?: boolean;
+    cssBundle?: boolean;
 }
 
 // Server Runner


### PR DESCRIPTION
followup to 94d8d7f747ca8456927c785445d5689b0e98bb17

This lets us use the cssBundle property